### PR TITLE
Fix typos in url and project_urls

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,9 +7,9 @@ license = GPLv3
 description = Wrapper of the CoinGecko API
 long_description = file: README.md
 long_description_content_type = text/markdown
-url = https://wwww.github.com/Ran-n/coingecko_api
+url = https://www.github.com/Ran-n/coingecko_api
 project_urls =
-    Bug Tracker = https://wwww.github.com/Ran-n/coingecko_api/issues
+    Bug Tracker = https://www.github.com/Ran-n/coingecko_api/issues
 classifiers =
     Development Status :: 3 - Alpha
     Environment :: Console


### PR DESCRIPTION
Before: wwww.github.com
After: www.github.com
- There were 4 times W in there, which caused the URL to become invalid.